### PR TITLE
Fix bad slide urls

### DIFF
--- a/chapters/day1_intro.qmd
+++ b/chapters/day1_intro.qmd
@@ -5,7 +5,7 @@
 <br />
 {{< fa user >}} &nbsp;**Author:** [Catherine Matias](http://cmatias.perso.math.cnrs.fr/)<br/>
 {{< fa brands github >}} &nbsp;**Source:** <https://github.com/econetoolbox/data/tree/main/day1_files/><br/>
-{{< fa globe >}} &nbsp;**Slides:** <https://econettoolbox.github.io/chapters/cours/day1_cours1_intro.pdf>
+{{< fa globe >}} &nbsp;**Slides:** <https://econetoolbox.github.io/chapters/cours/day1_cours1_intro.pdf>
 :::
 
 

--- a/chapters/day1_what-eco-net.qmd
+++ b/chapters/day1_what-eco-net.qmd
@@ -4,7 +4,7 @@
 
 <br />
 {{< fa user >}} &nbsp;**Author:** [Sonia Kéfi](https://isem-evolution.fr/en/membre/kefi/)<br/>
-{{< fa globe >}} &nbsp;**Slides:** <https://econettoolbox.github.io/chapters/cours/day1_cours2_WhatNetworks.pdf>
+{{< fa globe >}} &nbsp;**Slides:** <https://econetoolbox.github.io/chapters/cours/day1_cours2_WhatNetworks.pdf>
 :::
 
 

--- a/chapters/day1_what-eco-net2.qmd
+++ b/chapters/day1_what-eco-net2.qmd
@@ -4,7 +4,7 @@
 
 <br />
 {{< fa user >}} &nbsp;**Author:** [Elisa Thébault](https://iees-paris.fr/annuaire/thebault-elisa/)<br/>
-{{< fa globe >}} &nbsp;**Slides:** <https://econettoolbox.github.io/chapters/cours/day1_cours3_WhatNetworks.pdf>
+{{< fa globe >}} &nbsp;**Slides:** <https://econetoolbox.github.io/chapters/cours/day1_cours3_WhatNetworks.pdf>
 :::
 
 

--- a/chapters/day1_why-net.qmd
+++ b/chapters/day1_why-net.qmd
@@ -4,7 +4,7 @@
 
 <br />
 {{< fa user >}} &nbsp;**Author:** [Elisa Thébault](https://iees-paris.fr/annuaire/thebault-elisa/)<br/>
-{{< fa globe >}} &nbsp;**Slides:** <https://econettoolbox.github.io/chapters/cours/day1_cours4_WhyNetworks.pdf>
+{{< fa globe >}} &nbsp;**Slides:** <https://econetoolbox.github.io/chapters/cours/day1_cours4_WhyNetworks.pdf>
 :::
 
 

--- a/chapters/day2_complex-stab.qmd
+++ b/chapters/day2_complex-stab.qmd
@@ -4,7 +4,7 @@
 
 <br />
 {{< fa user >}} &nbsp;**Author:** [Sonia Kéfi](https://isem-evolution.fr/en/membre/kefi/)<br/>
-{{< fa globe >}} &nbsp;**Slides:** <https://econettoolbox.github.io/chapters/cours/day2_cours2_complexStab.pdf>
+{{< fa globe >}} &nbsp;**Slides:** <https://econetoolbox.github.io/chapters/cours/day2_cours2_complexStab.pdf>
 :::
 
 

--- a/chapters/day2_metrics.qmd
+++ b/chapters/day2_metrics.qmd
@@ -5,7 +5,7 @@
 <br />
 {{< fa user >}} &nbsp;**Author:** [François Massol](https://sites.google.com/a/polytechnique.org/francoismassol/home?pli=1)<br/>
 {{< fa brands github >}} &nbsp;**Source:** <https://github.com/econetoolbox/data/tree/main/day2_files/><br/>
-{{< fa globe >}} &nbsp;**Slides:** <https://econettoolbox.github.io/chapters/cours/day2_cours_metrics.pdf>
+{{< fa globe >}} &nbsp;**Slides:** <https://econetoolbox.github.io/chapters/cours/day2_cours_metrics.pdf>
 :::
 
 

--- a/chapters/day3_sbm.qmd
+++ b/chapters/day3_sbm.qmd
@@ -5,7 +5,7 @@
 <br />
 {{< fa user >}} &nbsp;**Author:** [Sophie Donnet](https://sophiedonnet.github.io/)<br/>
 {{< fa brands github >}} &nbsp;**Source:** <https://github.com/econetoolbox/data/tree/main/day3_files/><br/>
-{{< fa globe >}} &nbsp;**Slides:** <https://econettoolbox.github.io/chapters/cours/day3_cours_SBM_LBM.pdf>
+{{< fa globe >}} &nbsp;**Slides:** <https://econetoolbox.github.io/chapters/cours/day3_cours_SBM_LBM.pdf>
 :::
 
 

--- a/chapters/day4_multilevel.qmd
+++ b/chapters/day4_multilevel.qmd
@@ -5,7 +5,7 @@
 <br />
 {{< fa user >}} &nbsp;**Author:** [Sophie Donnet](https://sophiedonnet.github.io/)<br/>
 {{< fa brands github >}} &nbsp;**Source:** <https://github.com/econetoolbox/data/tree/main/day4_files/><br/>
-{{< fa globe >}} &nbsp;**Slides:** <https://econettoolbox.github.io/chapters/cours/day4_cours_multilevels.pdf>
+{{< fa globe >}} &nbsp;**Slides:** <https://econetoolbox.github.io/chapters/cours/day4_cours_multilevels.pdf>
 :::
 
 

--- a/chapters/day5_collection.qmd
+++ b/chapters/day5_collection.qmd
@@ -4,7 +4,7 @@
 
 <br />
 {{< fa user >}} &nbsp;**Author:** [Sophie Donnet](https://sophiedonnet.github.io/)<br/>
-{{< fa globe >}} &nbsp;**Slides:** <https://econettoolbox.github.io/chapters/cours/day5_cours_collection.pdf>
+{{< fa globe >}} &nbsp;**Slides:** <https://econetoolbox.github.io/chapters/cours/day5_cours_collection.pdf>
 :::
 
 


### PR DESCRIPTION
This PR fixes typo in URLs linking to original slides in the **Course** pages.
Replace `econettoolbox` by `econetoolbox`